### PR TITLE
Remove extraneous files from the published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Schwartzian transform",
   "main": "index.js",
+  "files": [],
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
Add a [`files`](https://docs.npmjs.com/files/package.json#files) entry to the `package.json` to avoid packaging extraneous files, e.g. the ctags file (`tags`) and `test.js`. The array is empty as the relevant files are included by default.